### PR TITLE
Add November blog post and others items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+public
+themes

--- a/config.toml
+++ b/config.toml
@@ -35,15 +35,3 @@ theme = "hugo-theme-learn"
   ordersectionsby = "weight"
   # Change default color scheme with a variant one. Can be "red", "blue", "green".
   themeVariant = "blue"
-
-[[menu.shortcuts]]
-name = "<i class='fab fa-github'></i> Github"
-identifier = "ds"
-url = "https://github.com/antonym/netboot.xyz"
-weight = 10
-
-[[menu.shortcuts]]
-name = "<i class='fas fa-external-link-alt'></i> netboot.xyz Store"
-identifier = "netboot.xyz-gear"
-url = "https://teespring.com/stores/netbootxyz"
-weight = 20

--- a/content/_index.md
+++ b/content/_index.md
@@ -19,11 +19,16 @@ You can remote attach the ISO to servers, set it up as a rescue option in Grub, 
 
 [Download](https://netboot.xyz/downloads/) one of the netboot.xyz bootloaders that works for your situation and start PXE booting your favorite operating system.  The bootloaders are precompiled versions of the latest version of [iPXE](https://github.com/ipxe/ipxe) that will allow you to PXE boot into [https://boot.netboot.xyz](https://boot.netboot.xyz).  If you have DHCP it'll automatically attempt to boot from DHCP.  If you need to set a static IP address, hit the 'm' key during boot up for the failsafe menu and choose manual network configuration.
 
-If you already have iPXE up and running on the network, you can hit netboot.xyz at anytime by typing:
+If you already have iPXE up and running on the network, you can hit load the netboot.xyz kernel by typing the following when loaded in a legacy BIOS:
 
-    chain --autofree https://boot.netboot.xyz
+    chain --autofree https://boot.netboot.xyz/ipxe/netboot.xyz.lkrn
 
-You'll need to make sure to have [DOWNLOAD_PROTO_HTTPS](https://github.com/ipxe/ipxe/blob/master/src/config/general.h#L57) enabled when compiling iPXE.
+or when in EFI mode:
+    
+    chain --autofree https://boot.netboot.xyz/ipxe/netboot.xyz.efi
+
+
+This will load the appropriate netboot.xyz kernel with all of the proper options enabled.
 
 ### Source Code
 
@@ -31,12 +36,12 @@ The source code for netboot.xyz is located [here](https://github.com/antonym/net
 
 ### Contributing
 
-New version of an operating system out?  Found one that network boots well with iPXE?  Pull requests are welcomed and encouraged and helps me out a ton!  Feel free to issue a pull request for new versions or tools that you might find useful.  Once merged into master, [Travis CI](https://travis-ci.org/antonym/netboot.xyz) will regenerate new versions of [iPXE from upstream](https://github.com/ipxe/ipxe) and deploy the latest changes to netboot.xyz.  See more on contributing [here](https://netboot.xyz/contributing).
+New version of an operating system out?  Found one that network boots well with iPXE?  Pull requests are welcomed and encouraged and helps out a ton!  Feel free to issue a pull request for new versions or tools that you might find useful.  Once merged into master, [Travis CI](https://travis-ci.org/antonym/netboot.xyz) will regenerate new versions of [iPXE from upstream](https://github.com/ipxe/ipxe) and deploy the latest changes to netboot.xyz.  See more on contributing [here](https://netboot.xyz/contributing).
 
 ### Testing New Branches
 
 Under the **Utilities** menu on netboot.xyz, there's an option for ["Test netboot.xyz branch"](https://github.com/antonym/netboot.xyz/blob/master/src/utils.ipxe#L157).  If you've forked the code and have developed a new feature branch, you can use this option to chainload into that branch to test and validate the code.  All you need to do is specify your Github user name and the name of your branch or abbreviated hash of the commit. Also, disable the signature verification for *netboot.xyz* under **Signatures Checks**.
 
-### Feedback
+### Communication
 
-Feel free to open up an [issue](https://github.com/antonym/netboot.xyz/issues) on Github, swing by [Freenode IRC](http://freenode.net/) in the [#netbootxyz](http://webchat.freenode.net/?channels=#netbootxyz) channel, or join us on our [Discord](https://discord.gg/An6PA2a) server.  Follow us on [Twitter](https://twitter.com/netbootxyz) or like us on [Facebook](https://www.facebook.com/netboot.xyz)!
+Feel free to open up an [issue](https://github.com/antonym/netboot.xyz/issues) on Github or join us on our [Discord](https://discord.gg/An6PA2a) server.  Follow us on [Twitter](https://twitter.com/netbootxyz) or like us on [Facebook](https://www.facebook.com/netboot.xyz)!

--- a/content/blog/2015-11-25-introducing-netboot.xyz.md
+++ b/content/blog/2015-11-25-introducing-netboot.xyz.md
@@ -1,5 +1,5 @@
 ---
-title: "netboot.xyz"
+title: "Introducing netboot.xyz"
 date: 2015-11-25T07:41:21-07:00
 draft: false
 ---

--- a/content/blog/2019-11-29-self-hosting-and-live-booting.md
+++ b/content/blog/2019-11-29-self-hosting-and-live-booting.md
@@ -1,0 +1,42 @@
+---
+title: "Self Hosting and Live Booting"
+date: 2019-11-29T07:41:21-07:00
+draft: false
+---
+
+{{< publishedDate >}}
+
+We have been hard at work the last few weeks and I wanted to provide some updates as to what we're currently working on and where we want to go.
+
+I would like to thank all of the contributers over the last few years that have contributed code, tested, and provided feedback for the project. The contributions have all been really helpful and have helped keep the project up to date.
+
+### Self Hosting
+
+I have been working on getting the netboot.xyz source tree to a point where they can be generated via Ansible so that anyone can take the repository and customize it to their liking a lot easier than it was in the past. I have gotten most of that working and will be swapping out the existing source bits in the netboot.xyz repo with the bits to deploy with Ansible. My goal is to generate the primary netboot.xyz site using Ansible instead of just uploading the source files. There will still be a lot of future optimizations that can be done to the templates but this is a good first step toward consolidating a lot of the duplicate code.
+
+The new netboot.xyz repo will allow you to create a self-hosted environment using Ansible to a target or you can use Docker to generate the site.  The Ansible playbooks will:
+
+* Generate the iPXE files from templates using default settings which can be overrideen
+* Generate all iPXE disks customized to your environment
+
+This should make it a lot easier to get a custom environment set up in the environment of your choosing.
+
+### Live Booting
+
+One of the things I have been wanting to do a for a while is provide a way to Live Boot more operating systems.  I always wanted to make netboot.xyz a place where anyone can try out new operating systems, reinstall, or rescue their favorite from one place. A lot of the operating systems out there don't always provide installer kernels and only host a large ISO as their release. With iPXE, the best way to load ISOs into memory is with memdisk or sandisk, but that starts to fail with larger images and doesn't work in EFI mode. Getting distros to change how they release their operating systems for iPXE users probably isn't going to happen anytime soon either.
+
+With a lot of help and expertise from [TheLamer (Ryan Kuba)](https://github.com/thelamer), a [linuxserver.io](https://linuxserver.io) contributor, we have built an automated pipeline that tracks and builds some of the latest Linux Live distributions, extracts kernels and squashfs assets, and loads them up as Github releases.  From there the information for each release is then put into the netboot.xyz repo, and we can then generate menus dynamically for each version.  This allows you to netboot into your favorite live distribution from the hosted Github release directly.  It is currently marked as experimental but we have a number of Live Operating Systems available already to start using.
+
+### Moving netboot.xyz repository
+
+I will be moving the repo from my personal repository on github to the [netbootxyz](https://github.com/netbootxyz) organization to put everything in one central place. The existing links should redirect to the new location.
+
+### Discord
+
+Over the last few weeks, we've been leveraging Discord more for communication for development, build automation, and discussion. If you would like to join in the discussion, you can join [here](https://discord.gg/An6PA2a).
+
+### Open Collective
+
+We have set up an [Open Collective](https://opencollective.com/netbootxyz) to open the project up to those who wish to donate to help out the project. This may cover hosting and domain fees, hardware for validation testing, or anything else that comes up in maintaining a project like this. Every little bit will help! If you enjoy the work we do, please support us!
+
+Thanks again for all of your support and we hope to continue making this project more useful for our users!

--- a/content/blog/_index.md
+++ b/content/blog/_index.md
@@ -7,4 +7,6 @@ hidden: false
 alwaysopen: false
 ---
 
-{{< blog/indexcard date="November 25, 2015" title="netboot.xyz" page="2015-11-25-netboot.xyz" >}}
+{{< blog/indexcard date="November 29, 2019" title="Self Hosting and Live Booting" page="2019-11-29-self-hosting-and-live-booting" >}}
+
+{{< blog/indexcard date="November 25, 2015" title="Introducing netboot.xyz" page="2015-11-25-introducing-netboot.xyz" >}}

--- a/content/contributing/_index.md
+++ b/content/contributing/_index.md
@@ -54,10 +54,13 @@ idea, feel free to open up a Github [issue] or open up a [Pull Request].
 
 ### Communication Channels
 
-* [Discord](https://discord.gg/An6PA2a) Chat Server for netboot.xyz discussions and questions.
-* Follow us on [Twitter](https://twitter.com/netbootxyz) with [@netbootxyz](https://twitter.com/netbootxyz)
+* [Discord](https://discord.gg/An6PA2a) Chat Server for netboot.xyz discussions, questions, and development
+* Follow us on [Twitter](https://twitter.com/netbootxyz) at [@netbootxyz](https://twitter.com/netbootxyz)
   for the latest updates
-* [Freenode IRC](http://webchat.freenode.net/?channels=%23netbootxyz&uio=d4) in #netbootxyz
+
+### Donate
+
+We have set up an [Open Collective](https://opencollective.com/netbootxyz) to open the project up to those who wish to donate to help out the project. This may cover hosting and domain fees, hardware for validation testing, or anything else that comes up in maintaining a project like this. Every little bit will help! If you enjoy the work we do, please support us!
 
 ## Enjoy and have fun!
 

--- a/content/faq/_index.md
+++ b/content/faq/_index.md
@@ -60,10 +60,6 @@ Yes!  You can fork [netboot.xyz-custom](https://github.com/antonym/netboot.xyz-c
 * [Tiny Core Linux](http://tinycorelinux.net)
 * [Ubuntu](http://www.ubuntu.com/)
 
-### Hypervisors
-
-* [Citrix XenServer](http://xenserver.org)
-
 ### Security Related
 
 * [BlackArch Linux](https://blackarch.org)

--- a/layouts/partials/menu-footer.html
+++ b/layouts/partials/menu-footer.html
@@ -5,6 +5,10 @@
     <!-- Place this tag where you want the button to render. -->
     <a class="github-button" href="https://github.com/antonym/netboot.xyz/fork" data-icon="octicon-repo-forked" data-show-count="true" aria-label="Fork antonym/netboot.xyz on GitHub">Fork</a>
 
+    <p><a href="https://opencollective.com/netbootxyz/donate" target="_blank">
+      <img src="https://opencollective.com/netbootxyz/donate/button@2x.png?color=blue" width=200 />
+    </a></p>
+
     <p>© 2019 <a href="https://twitter.com/@ntonym">Antony Messerli</a></p>
 </center>
 <!-- Place this tag in your head or just before your close body tag. -->


### PR DESCRIPTION
* Adds Novemeber blog post
* Adds gitignore for hugo dirs
* Drops store for now, will revisit
* Adds Open Collective links
* Tweaks links for loading netboot.xyz from generic iPXE
  to load kernels directly so that HTTPS support is loaded
* Removes Citrix link
* Removes Freenode channel link to focus on Discord