### PR TITLE
Fix dead links and URI schemes

### DIFF
--- a/blog/2016-01-07-booting-linux-isos-with-memdisk-and-ipxe.md
+++ b/blog/2016-01-07-booting-linux-isos-with-memdisk-and-ipxe.md
@@ -40,13 +40,15 @@ memdiskfind can be compiled with the klibc instead of with the glibc C library t
 
 ### Implementations of phram and mtdblock
 
-ArchLinux has implemented the above concept [here](https://projects.archlinux.org/mkinitcpio.git/tree/install/memdisk) and [here](https://projects.archlinux.org/mkinitcpio.git/tree/hooks/memdisk).
+ArchLinux has implemented the above concept [here](https://gitlab.archlinux.org/archlinux/mkinitcpio/mkinitcpio/-/blob/master/install/memdisk) and [here](https://gitlab.archlinux.org/archlinux/mkinitcpio/mkinitcpio/-/blob/master/hooks/memdisk).
 
 Debian Live used it [here](https://anonscm.debian.org/cgit/debian-live/live-boot.git/commit/?id=e08c082e758afa3341a9ebb6e00927d9873c7230).
 
 It's also been implemented in Clonezilla and [GParted](http://gparted-forum.surf4.info/viewtopic.php?id=17263).
 
 [Antergos Linux](https://antergos.com/) based on Arch Linux works great with memdisk using the phram module.
+
+_Editor's Note: Antergos Linux is defunct.  Visit the archived website [here](https://web.archive.org/web/20190816015938/https://antergos.com/).  Antergos Linux's sucessor is [Endeavour OS](https://endeavouros.com/)._
 
 ### Conclusion
 
@@ -61,4 +63,4 @@ Some of the distributions I'd love to see network support or better memdisk supp
 
 There are also many other new distributions being released all the time.  I typically use [DistroWatch](http://distrowatch.com/) to determine the most popular distributions to attempt to add to [netboot.xyz](http://netboot.xyz).  I'd love to get a lot of these added to make it really easy to install anything on the fly.
 
-I'd also love to see some of the hypervisors out there crack open the ISOs, pull them outside of their paywalls, and host the bits on their servers so that it's much easier to immediately boot an install to test something out without having to jump through many hoops.  I have working installs for [VMware ESX](https://www.vmware.com/products/esxi-and-esx/overview) and [Citrix XenServer](http://xenserver.org/overview-xenserver-open-source-virtualization/download.html) but I'd need to have them host the bits or allow permission to do so for a public facing installer menu.
+I'd also love to see some of the hypervisors out there crack open the ISOs, pull them outside of their paywalls, and host the bits on their servers so that it's much easier to immediately boot an install to test something out without having to jump through many hoops.  I have working installs for [VMware ESX](https://www.vmware.com/products/esxi-and-esx/overview) and [Citrix Hypervisor (formerly Citrix XenServer)](https://www.citrix.com/products/citrix-hypervisor/) but I'd need to have them host the bits or allow permission to do so for a public facing installer menu.

--- a/docs/booting/qemu.md
+++ b/docs/booting/qemu.md
@@ -16,7 +16,7 @@ A quick way to try out netboot.xyz without any modifications to your existing en
 sudo apt-get install -y qemu-system ovmf
 
 # download the latest combined Legacy and EFI iso
-wget http://boot.netboot.xyz/ipxe/netboot.xyz.iso
+wget https://boot.netboot.xyz/ipxe/netboot.xyz.iso
 ```
 
 If you want to write to a disk, you can set one at this point, or optionally you can boot without a disk if you want to test drive netboot.xyz:

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -18,7 +18,7 @@ PXE stands for **P**re-Boot e**X**ecution **E**nvironment.  PXE booting has been
 ### Will my favorite distribution work with netboot.xyz?
 Usually you need three things to boot up an OS over the network, the vmlinuz, the initramfs, and the rootfs.  Distributions that support an installer kernel hosted on a mirror are typically the easier ones to implement as they are very lightweight.  Distributions that only release ISOs are typically a bit more involved to implement as we have to use memdisk to load it up into memory.
 
-From [syslinux - memdisk](http://www.syslinux.org/wiki/index.php/MEMDISK): The majority of Linux based CD images will also fail to work with MEMDISK ISO emulation. Linux distributions require kernel and initrd files to be specified, as soon as these files are loaded the protected mode kernel driver(s) take control and the virtual CD will no longer be accessible. If any other files are required from the CD/DVD they will be missing, resulting in boot error(s). Linux distributions that only require kernel and initrd files function fully via ISO emulation, as no other data needs accessing from the virtual CD/DVD drive once they have been loaded. The boot loader has read all necessary files to memory by using INT 13h, before booting the kernel.
+From [syslinux - memdisk](https://www.syslinux.org/wiki/index.php/MEMDISK): The majority of Linux based CD images will also fail to work with MEMDISK ISO emulation. Linux distributions require kernel and initrd files to be specified, as soon as these files are loaded the protected mode kernel driver(s) take control and the virtual CD will no longer be accessible. If any other files are required from the CD/DVD they will be missing, resulting in boot error(s). Linux distributions that only require kernel and initrd files function fully via ISO emulation, as no other data needs accessing from the virtual CD/DVD drive once they have been loaded. The boot loader has read all necessary files to memory by using INT 13h, before booting the kernel.
 
 To get around these limitations, especially since memdisk is not supported with UEFI, we have built a CI/CD system that consumes the ISOs from upstream projects and prepares the needed files to boot the operating system remotely as a release.  In some cases this may involve a small modification to the init scripts in order to tune the network boot flexibility or handle multiple parts for larger operating systems.  Those releases are added to the endpoints.yml in the main netboot.xyz repo and are then available for download.
 
@@ -56,7 +56,7 @@ iPXE and hence netboot.xyz does not support Secure Boot because its [binaries ar
 | Bluestar Linux | https://sourceforge.net/projects/bluestarlinux | No | Yes |
 | Bodhi Linux | https://www.bodhilinux.com | No | Yes |
 | CentOS | https://centos.org | Yes | No |
-| CoreOS | http://coreos.com/ | Yes | No |
+| Fedora CoreOS | https://getfedora.org/en/coreos?stream=stable | Yes | No |
 | Debian | https://debian.org | Yes | Yes|
 | Deepin | https://www.deepin.org | No | Yes |
 | Devuan | https://devuan.org | Yes | No |
@@ -67,7 +67,7 @@ iPXE and hence netboot.xyz does not support Secure Boot because its [binaries ar
 | Feren OS | https://ferenos.weebly.com/ | Yes | No |
 | Flatcar Linux | https://kinvolk.io/flatcar-container-linux/ | Yes | No |
 | FreeBSD | https://freebsd.org | Yes, disk image | No |
-| FreeDOS | http://www.freedos.org | ISO - Memdisk| No |
+| FreeDOS | https://www.freedos.org | ISO - Memdisk| No |
 | Garuda Linux | https://garudalinux.org/ | No | Yes |
 | Gentoo | https://gentoo.org | Yes | Yes |
 | Harvester | https://harvesterhci.io | Yes | No |
@@ -83,11 +83,11 @@ iPXE and hence netboot.xyz does not support Secure Boot because its [binaries ar
 | Manjaro | https://manjaro.org | No | Yes |
 | Mint | https://linuxmint.com | No | Yes |
 | Microsoft Windows | https://www.microsoft.com | User supplied media | No |
-| MirOS | https://www.mirbsd.org | Yes | No |
+| MirOS | http://www.mirbsd.org | Yes | No |
 | Nitrux | https://nxos.org/ | No | Yes |
 | NixOS | https://nixos.org | Yes | No |
 | OpenBSD | https://openbsd.org | Yes | No |
-| openEuler | https://openeuler.org | Yes | No |
+| openEuler | https://www.openeuler.org/ | Yes | No |
 | OpenSUSE | https://opensuse.org | Yes | No |
 | Oracle Linux | https://www.oracle.com/linux/ | Yes | Installer |
 | Parrot Security | https://www.parrotsec.org | No | Yes |
@@ -107,7 +107,7 @@ iPXE and hence netboot.xyz does not support Secure Boot because its [binaries ar
 | SparkyLinux | https://sparkylinux.org/ | No | Yes |
 | Tails | https://tails.boum.org/ | No | Yes |
 | Talos | https://www.talos.dev/ | Yes | No |
-| Tiny Core Linux | https://tinycorelinux.net | Yes | Yes |
+| Tiny Core Linux | http://www.tinycorelinux.net/ | Yes | Yes |
 | Ubuntu | https://www.ubuntu.com | Yes | Yes |
 | VMware | https://www.vmware.com | User supplied media | No |
 | Voyager | https://voyagerlive.org | No | Yes |
@@ -123,26 +123,26 @@ iPXE and hence netboot.xyz does not support Secure Boot because its [binaries ar
 | ALT Linux Rescue | https://en.altlinux.org/Rescue | ISO - Memdisk |
 | BakAndImgCD | https://bakandimgcd.4mlinux.com/ | Kernel/Initrd |
 | Boot Repair CD | https://sourceforge.net/projects/boot-repair-cd/ | LiveCD |
-| Breakin | http://www.advancedclustering.com/products/software/breakin/ | Kernel/Initrd |
+| Breakin | https://www.advancedclustering.com/products/software/breakin/ | Kernel/Initrd |
 | CAINE | https://www.caine-live.net/ | LiveCD |
-| Clonezilla | http://www.clonezilla.org/ | LiveCD |
-| DBAN | http://www.dban.org/ | Kernel |
-| GParted | http://gparted.org | LiveCD |
-| Grml | http://grml.org | LiveCD |
+| Clonezilla | https://clonezilla.org/ | LiveCD |
+| DBAN | https://dban.org/ | Kernel |
+| GParted | https://gparted.org | LiveCD |
+| Grml | https://grml.org | LiveCD |
 | Kaspersky Rescue Disk | https://support.kaspersky.com/viruses/krd18 | LiveCD |
-| Memtest | http://www.memtest.org/ | Kernel |
+| Memtest | https://www.memtest.org/ | Kernel |
 | MemTest86 Free | https://www.memtest86.com | USB Img |
 | Redo Rescue | http://redorescue.com/ | LiveCD |
 | Rescatux | https://www.supergrubdisk.org/rescatux/ | LiveCD |
 | Rescuezilla | https://rescuezilla.com/ | LiveCD |
 | ShredOS | https://github.com/PartialVolume/shredos.x86_64 | Kernel | 
-| Super Grub2 Disk | http://www.supergrubdisk.org | ISO - Memdisk |
-| System Rescue | https://system-rescue.org/ | LiveCD |
+| Super Grub2 Disk | https://www.supergrubdisk.org/ | ISO - Memdisk |
+| System Rescue | https://www.system-rescue.org/ | LiveCD |
 | The Smallest Server Suite | https://thesss.4mlinux.com/ | Kernel/Initrd |
-| Ultimate Boot CD | http://www.ultimatebootcd.com | ISO - Memdisk |
+| Ultimate Boot CD | https://www.ultimatebootcd.com/ | ISO - Memdisk |
 
 ### What are some good resources for learning more about network booting?
 
-* [The iPXE Project](http://ipxe.org/)
-* [NetworkBoot.org](http://networkboot.org/)
-* [Syslinux Project](http://www.syslinux.org/wiki/index.php?title=The_Syslinux_Project)
+* [The iPXE Project](https://ipxe.org/)
+* [NetworkBoot.org](https://networkboot.org/)
+* [Syslinux Project](https://www.syslinux.org/wiki/index.php?title=The_Syslinux_Project)

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -6,7 +6,7 @@ hide_table_of_contents: true
 slug: /
 ---
 
-[netboot.xyz](http://netboot.xyz) lets you [PXE](https://en.wikipedia.org/wiki/Preboot_Execution_Environment) boot various operating system installers or utilities from a single tool over the network. This lets you use one media for many types of operating systems or tools. The [iPXE](http://ipxe.org/) project is used to provide a user friendly menu from within the BIOS that lets you easily choose the operating system you want along with any specific types of versions or bootable flags.
+[netboot.xyz](https://netboot.xyz) lets you [PXE](https://en.wikipedia.org/wiki/Preboot_Execution_Environment) boot various operating system installers or utilities from a single tool over the network. This lets you use one media for many types of operating systems or tools. The [iPXE](https://ipxe.org/) project is used to provide a user friendly menu from within the BIOS that lets you easily choose the operating system you want along with any specific types of versions or bootable flags.
 
 You can remote attach the ISO to servers, set it up as a rescue option in Grub, or even set up your home network to boot to it by default so that it's always available.
 

--- a/docs/kb/networking/edgerouter.md
+++ b/docs/kb/networking/edgerouter.md
@@ -193,7 +193,7 @@ option ipxe.sdi       code 40 = unsigned integer 8;
 option ipxe.nfs       code 41 = unsigned integer 8;
 
 # Other useful general options
-# http://www.ietf.org/assignments/dhcpv6-parameters/dhcpv6-parameters.txt
+# https://www.iana.org/assignments/dhcpv6-parameters/dhcpv6-parameters.xhtml
 option arch code 93 = unsigned integer 16;
 ```
 


### PR DESCRIPTION
I also added an editor's note about Antergos's defunct status with a reference to its successor.

This changes a few HTTPS urls to HTTP - this is intentional - it turns out the MirBSD.org webserver does not work with modern browsers.  I contacted mirabilos (the maintainer) to ask what he wants done - he suggested I use HTTP for now.

Additionally tinycore linux no longer operates a HTTPS website.  It appears HTTP only.

As a note to myself and others, here is how you can (roughly) test the links:

```bash
grep -hrEo "(http|https)://[a-zA-Z0-9./?=_%:-]*" blog docs |
    sort -u |
    while read -r url; do
        echo -n '.'
        curl -sS -I -m 5 "$url" >/dev/null || printf '\n%s\n' "$url"
    done
```