### PR TITLE
Add Oracle Cloud Infrastructure instructions for kb/providers docs

### DIFF
--- a/docs/kb/providers/oci.md
+++ b/docs/kb/providers/oci.md
@@ -17,7 +17,7 @@ Take note of which shape you take, as it will determine further steps:
 - AMD (`x86_64`)
 - Ampere A1 (`arm64`)
 
-:::info
+:::caution
 Set up SSH keys!
 You will need to log into the server and there is no default password.
 
@@ -100,6 +100,6 @@ If you make a mistake, move with arrow keys, and use the Delete key.
 
 Once you have typed it in, you might have to press the Escape key twice.
 
-:::note
-If you were not able to boot into netboot.xyz correctly, simple repeat the `grub-reboot` and `reboot` steps to enter UEFI again.
+:::caution
+This is **not** applicable to `arm64`/Ampere A1.
 :::

--- a/docs/kb/providers/oci.md
+++ b/docs/kb/providers/oci.md
@@ -79,7 +79,19 @@ sudo grub-reboot "UEFI Firmware Settings"
 sudo reboot
 ```
 
-##### Console quirks: Linux
+### Boot into netboot.xyz
+Now that you are in the UEFI Firmware, do the following:
+- Choose “Boot Maintenance Manager”
+- Choose “Boot From File”
+- Choose the only device
+- Choose the netboot.xyz EFI file
+- Wait for it to start and configure
+
+:::tip
+If you were not able to boot into netboot.xyz correctly, simple repeat the `grub-reboot` and `reboot` steps to enter UEFI again.
+:::
+
+#### `x86_64` - Console quirks: Linux
 Once you have booted into netboot.xyz on `x86_64`, if you plan on using Linux images, you must still set up custom `Kernel cmdline params` under `Utilities (UEFI)`.
 
 Set `Kernel cmdline params: []` to `console=ttyS0,9600`.

--- a/docs/kb/providers/oci.md
+++ b/docs/kb/providers/oci.md
@@ -14,8 +14,8 @@ When creating an instance, make sure to select:
 - Image: Ubuntu > Canonical Ubuntu (standard, not minimal)
 
 Take note of which shape you take, as it will determine further steps:
-- AMD (x86_64)
-- Ampere A1 (arm64)
+- AMD (`x86_64`)
+- Ampere A1 (`arm64`)
 
 Do set up SSH keys, as you will need to log into the server and there is no default password. We assume you know how to use SSH keys.
 

--- a/docs/kb/providers/oci.md
+++ b/docs/kb/providers/oci.md
@@ -20,9 +20,9 @@ Take note of which shape you take, as it will determine further steps:
 Do set up SSH keys, as you will need to log into the server and there is no default password. We assume you know how to use SSH keys.
 
 ### Get into the rescue shell
-First get onto your compute instance's details page, then scroll down to "Resources" under which you'll find "Console connection".
+First get onto your compute instance's details page, then scroll down to `Resources` under which you'll find `Console connection`.
 
-To get into the rescue shell, we recommend you use the Cloud Shell, and not bother with a "local connection". To do so, click on "Launch Cloud Shell connection" and wait for the console connection status to reach the "ACTIVE" state. Be patient, it can take a minute or two.
+To get into the rescue shell, we recommend you use the Cloud Shell, and not bother with a `local connection`. To do so, click on `Launch Cloud Shell connection` and wait for the console connection status to reach the `ACTIVE` state. Be patient, it can take a minute or two.
 
 You do not need to log in, as we'll only use it control the UEFI Firmware.
 
@@ -30,20 +30,16 @@ You do not need to log in, as we'll only use it control the UEFI Firmware.
 
 Now that you have the rescue shell open, you need to open a SSH connection to entere the following commands, as there is no default password.
 
-Follow the instructions depending on which architecture/shape you chose earlier: arm64 or x86_64.
-
-:::info
-If you were not able to boot into netboot.xyz correctly, simple repeat the `grub-reboot` and `reboot` steps to enter UEFI again.
-:::
+Follow the instructions depending on which architecture/shape you chose earlier: `arm64` or `x86_64`.
 
 :::info
 The rescue shell over the Oracle Cloud Shell can be somewhat buggy, for instance, you might have to press the Escape key twice instead of only once when in netboot.xyz
 :::
 
-#### arm64 - Ampere A1
-These steps apply to the Ampere A1 (arm64) instances.
+#### `arm64` - Ampere A1
+These steps apply to the Ampere A1 (`arm64`) instances.
 
-The default GRUB configuration already contains the "UEFI Firmware" option, so we only have to download netboot.xyz and reboot into the correct option.
+The default GRUB configuration already contains the `UEFI Firmware` option, so we only have to download netboot.xyz and reboot into the correct option.
 
 ```shell
 # Download netboot (arm64) into the EFI directory
@@ -56,10 +52,10 @@ sudo grub-reboot "UEFI Firmware Settings"
 sudo reboot
 ```
 
-#### x86_64 - AMD
-These steps apply to the AMD/Intel (x86_64) instances.
+#### `x86_64` - AMD
+These steps apply to the AMD/Intel (`x86_64`) instances.
 
-We need to delete the default GRUB configuration and regenerate it, as it does not contain "UEFI Firmware". Then, we can reboot into the UEFI Firmware and boot into netboot.xyz:
+We need to delete the default GRUB configuration and regenerate it, as it does not contain `UEFI Firmware`. Then, we can reboot into the UEFI Firmware and boot into netboot.xyz:
 
 ```shell
 # Download netboot (amd64) into the EFI directory
@@ -78,11 +74,15 @@ sudo grub-reboot "UEFI Firmware Settings"
 sudo reboot
 ```
 
-##### Console quirks
-Once you have booted into netboot.xyz on x86_64, if you plan on using Linux images, you must still set up custom `Kernel cmdline params` under `Utilities (UEFI)`.
+##### Console quirks: Linux
+Once you have booted into netboot.xyz on `x86_64`, if you plan on using Linux images, you must still set up custom `Kernel cmdline params` under `Utilities (UEFI)`.
 
 Set `Kernel cmdline params: []` to `console=ttyS0,9600`.
 
 If you make a mistake, move with arrow keys, and use the Delete key.
 
 Once you have typed it in, you might have to press the Escape key twice.
+
+:::note
+If you were not able to boot into netboot.xyz correctly, simple repeat the `grub-reboot` and `reboot` steps to enter UEFI again.
+:::

--- a/docs/kb/providers/oci.md
+++ b/docs/kb/providers/oci.md
@@ -1,0 +1,88 @@
+---
+id: oci
+title: Oracle Cloud Infrastructure
+description: Using netboot.xyz on Oracle Cloud Infrastructure
+hide_table_of_contents: true
+---
+
+netboot.xyz can be loaded on [OCI](https://www.oracle.com/cloud/) compute instances so that you can then customize the compute instance as needed.
+
+For this method, we'll use the standard Ubuntu image for the relevant architecture.
+
+### Create a compute instance
+When creating an instance, make sure to select:
+- Image: Ubuntu > Canonical Ubuntu (standard, not minimal)
+
+Take note of which shape you take, as it will determine further steps:
+- AMD (x86_64)
+- Ampere A1 (arm64)
+
+Do set up SSH keys, as you will need to log into the server and there is no default password. We assume you know how to use SSH keys.
+
+### Get into the rescue shell
+First get onto your compute instance's details page, then scroll down to "Resources" under which you'll find "Console connection".
+
+To get into the rescue shell, we recommend you use the Cloud Shell, and not bother with a "local connection". To do so, click on "Launch Cloud Shell connection" and wait for the console connection status to reach the "ACTIVE" state. Be patient, it can take a minute or two.
+
+You do not need to log in, as we'll only use it control the UEFI Firmware.
+
+### Download the EFI binary, Setup GRUB and Reboot into UEFI
+
+Now that you have the rescue shell open, you need to open a SSH connection to entere the following commands, as there is no default password.
+
+Follow the instructions depending on which architecture/shape you chose earlier: arm64 or x86_64.
+
+:::info
+If you were not able to boot into netboot.xyz correctly, simple repeat the `grub-reboot` and `reboot` steps to enter UEFI again.
+:::
+
+:::info
+The rescue shell over the Oracle Cloud Shell can be somewhat buggy, for instance, you might have to press the Escape key twice instead of only once when in netboot.xyz
+:::
+
+#### arm64 - Ampere A1
+These steps apply to the Ampere A1 (arm64) instances.
+
+The default GRUB configuration already contains the "UEFI Firmware" option, so we only have to download netboot.xyz and reboot into the correct option.
+
+```shell
+# Download netboot (arm64) into the EFI directory
+sudo wget -O /boot/efi/netboot.xyz-arm64.efi https://boot.netboot.xyz/ipxe/netboot.xyz-arm64.efi
+
+# Set the default boot entry (for the following boot only) to the UEFI firmware
+sudo grub-reboot "UEFI Firmware Settings"
+
+# Reboot the instance
+sudo reboot
+```
+
+#### x86_64 - AMD
+These steps apply to the AMD/Intel (x86_64) instances.
+
+We need to delete the default GRUB configuration and regenerate it, as it does not contain "UEFI Firmware". Then, we can reboot into the UEFI Firmware and boot into netboot.xyz:
+
+```shell
+# Download netboot (amd64) into the EFI directory
+sudo wget -O /boot/efi/netboot.xyz-snp.efi https://boot.netboot.xyz/ipxe/netboot.xyz-snp.efi
+
+# Delete the default configuration (does not contain UEFI Firmware by default)
+sudo rm -rf /etc/default/grub /etc/default/grub.d/
+
+# Update GRUB menu (with defalt configuration)
+sudo update-grub
+
+# Set the default boot entry (for the following boot only) to the UEFI firmware
+sudo grub-reboot "UEFI Firmware Settings"
+
+# Reboot
+sudo reboot
+```
+
+##### Console quirks
+Once you have booted into netboot.xyz on x86_64, if you plan on using Linux images, you must still set up custom `Kernel cmdline params` under `Utilities (UEFI)`.
+
+Set `Kernel cmdline params: []` to `console=ttyS0,9600`.
+
+If you make a mistake, move with arrow keys, and use the Delete key.
+
+Once you have typed it in, you might have to press the Escape key twice.

--- a/docs/kb/providers/oci.md
+++ b/docs/kb/providers/oci.md
@@ -17,7 +17,12 @@ Take note of which shape you take, as it will determine further steps:
 - AMD (`x86_64`)
 - Ampere A1 (`arm64`)
 
-Do set up SSH keys, as you will need to log into the server and there is no default password. We assume you know how to use SSH keys.
+:::info
+Set up SSH keys!
+You will need to log into the server and there is no default password.
+
+We assume you know how to use SSH keys.
+:::
 
 ### Get into the rescue shell
 First get onto your compute instance's details page, then scroll down to `Resources` under which you'll find `Console connection`.

--- a/sidebars.js
+++ b/sidebars.js
@@ -72,6 +72,7 @@ module.exports = {
             'kb/providers/equinixmetal',
             'kb/providers/gce',
             'kb/providers/linode',
+            'kb/providers/oci',
             'kb/providers/openstack',
             'kb/providers/vultr',
           ],


### PR DESCRIPTION
This adds instructions for use of netboot.xyz on Oracle Cloud, both for AMD and ARM instances.

They cover:
1. the creation of a compute instance
2. how to access to the rescue console
3. which commands to run (on `x86_64` and `arm64`) to boot into UEFI
4. how to access netboot.xyz from the UEFI Firmware
5. `x86_64` quirks for Linux

I've based these insturctions on [notes I wrote mid 2022](https://dailybuild.org/gemini/x/hoodie.quest/oracle.gmi) after enduring the painful process of getting it to work. I've then shared those notes with friends which were quite happy, so it only makes sense to contribute this back to upstream to allow for more people to use netboot.xyz on Oracle. (even more so with their default images not being extremely good and choice of images restricted)

I tried my best to stay close to the style of the other provider pages.