### PR TITLE
update grub2-mkconfig to add arg: -o /boot/grub2/grub.cfg

### DIFF
--- a/docs/booting/grub.md
+++ b/docs/booting/grub.md
@@ -36,7 +36,7 @@ ln -s /usr/share/grub/grub-mkconfig_lib /usr/lib/grub/grub-mkconfig_lib
 #Download iamgeboot config file
 wget https://raw.githubusercontent.com/formorer/grub-imageboot/529ac5d2bf91e7da8c31b9e15f37702127bddc1c/bin/60_grub-imageboot -O /etc/grub.d/60_grub-imageboot
 chmod 755 /etc/grub.d/60_grub-imageboot
-grub2-mkconfig
+grub2-mkconfig -o /boot/grub2/grub.cfg
 reboot
 ```
 


### PR DESCRIPTION
In Grub documentation for RHEL distro,
Updated line about grub2-mkconfig to grub2-mkconfig -o /boot/grub2/grub.cfg

On Rocky Linux, without this, it was not possible to boot to netboot.xyz for example.