### PR TITLE
add link to user_overrides.yml in selfhosting.md

### DIFF
--- a/docs/selfhosting.md
+++ b/docs/selfhosting.md
@@ -65,7 +65,7 @@ The build output will be in the generated folder `buildout`. Docker provides a c
 
 #### Local Overrides
 
-Ansible will handle source generation as well as iPXE disk generation with your settings.  It will generate Legacy (PCBIOS) and UEFI iPXE disks that can be used to load into your netboot.xyz environment. If you want to override the defaults, you can put overrides in user_overrides.yml.  See `user_overrides.yml` for examples.
+Ansible will handle source generation as well as iPXE disk generation with your settings.  It will generate Legacy (PCBIOS) and UEFI iPXE disks that can be used to load into your netboot.xyz environment. If you want to override the defaults, you can put overrides in user_overrides.yml.  See [`user_overrides.yml`](https://github.com/netbootxyz/netboot.xyz/blob/master/user_overrides.yml) for examples.
 
 Using the overrides file, you can override all of the settings from the defaults/main.yml so that you can easily change the boot mirror URLs when the menus are rendered.  If you prefer to do this after the fact, you can also edit the boot.cfg to make changes, but keep in mind those changes will not be saved when you redeploy the menu.
 


### PR DESCRIPTION
When reading the docs I had to search for the `user_overrides.yml`, and I thought a link would be helpful.