### PR TITLE
SmartOS has moved to MNX.io

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -113,7 +113,7 @@ We have a CI/CD system that monitors upstream projects for new releases. When a 
 | Scientific Linux | https://scientificlinux.org | Yes | No |
 | Septor | https://septor.sourceforge.io | No | Yes |
 | Slackware | https://www.slackware.com | Yes | No |
-| SmartOS | https://www.joyent.com/smartos | Yes | No |
+| SmartOS | https://www.smartos.org/ | Yes | No |
 | SparkyLinux | https://sparkylinux.org/ | No | Yes |
 | Tails | https://tails.boum.org/ | No | Yes |
 | Talos | https://www.talos.dev/ | Yes | No |


### PR DESCRIPTION
Hello!

SmartOS (and Triton) have moved out of Samsung to [MNX](https://mnx.io). Joyent has kept compatibility domain names for us, but it's time to switch everything over to their canonical URLs.

Along with this pull request, I have opened netbootxyz/netboot.xyz#1394.

If there is any infrastructure that references Joyent outside of github, I can help get that redirected to the proper location as well.