### PR TITLE
Add DHCP match for 64-bit UEFI arm64

### DIFF
--- a/docs/docker/dhcp.md
+++ b/docs/docker/dhcp.md
@@ -66,6 +66,7 @@ dhcp-boot=tag:efi64-2,netboot.xyz.efi,,SERVER_IP_ADDRESS
 
 # 64-bit UEFI for arm64
 dhcp-match=set:efi64-3,60,PXEClient:Arch:0000B
+dhcp-match=set:efi64-3,60,PXEClient:Arch:00011
 dhcp-boot=tag:efi64-3,netboot.xyz-arm64.efi,,SERVER_IP_ADDRESS
 ```
 


### PR DESCRIPTION
DHCP match criteria for hexadecimal didn't work on an ARM device we were testing. Changing the DHCP match criteria to decimal `00011` made it work again.

The device we used was a [Windows Dev Kit 2023](https://learn.microsoft.com/en-us/windows/arm/dev-kit/), which advertised their ID as follows (as seen from running `tcpdump -i eth0 -n port 67 or port 68 -vv`)
```
...
            GUID (97), length 17: <redacted>
            NDI (94), length 3: 1.3.16
            ARCH (93), length 2: 11
            Vendor-Class (60), length 32: "PXEClient:Arch:00011:UNDI:003016"
```

I wasn't sure of other ARM devices do actually advertise `0000B` so my PR didn't remove that matching entry.