### PR TITLE
SEO improvements, content quality fixes, and sidebar cleanup

### DIFF
--- a/docs/docker/overview.md
+++ b/docs/docker/overview.md
@@ -1,5 +1,6 @@
 ---
 title: netboot.xyz Docker Container Overview
+sidebar_label: Overview
 sidebar_position: 1
 slug: /docker/
 description: "The netboot.xyz Docker container provides a self-hosted PXE boot server with a web UI, TFTP, NGINX, and local asset mirroring."

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -1,7 +1,7 @@
 ---
 id: introduction
 sidebar_position: 1
-title: "netboot.xyz — PXE Boot Any OS Over the Network"
+title: Introduction
 description: "netboot.xyz lets you PXE boot Linux installers, live CDs, and utilities over the network from a single iPXE-powered menu. No media required."
 hide_table_of_contents: true
 slug: /

--- a/docs/kb/pxe/windows.md
+++ b/docs/kb/pxe/windows.md
@@ -1,6 +1,7 @@
 ---
 id: windows
 title: "Installing Windows via PXE Network Boot with netboot.xyz"
+sidebar_label: Windows
 description: "Install Windows 11 over the network using netboot.xyz, WinPE, and the Docker container with an SMB share for the Windows ISO."
 hide_table_of_contents: true
 ---

--- a/docs/troubleshooting/_category_.yml
+++ b/docs/troubleshooting/_category_.yml
@@ -1,0 +1,6 @@
+label: Troubleshooting Guide
+position: 8
+collapsed: true
+link:
+  type: doc
+  id: troubleshooting/index


### PR DESCRIPTION
## Summary

- SEO pass: improved titles, descriptions, and internal linking across 20+ doc pages and all 6 blog posts
- Content fixes: grammar, typos, outdated Secure Boot FAQ answer, FAQ headings updated to match real search queries
- Sidebar fixes: reverted long page titles that broke the sidebar layout; added `sidebar_label` where needed; moved Troubleshooting to the bottom of the sidebar

## Changes by commit

**`seo: improve titles, descriptions, and internal linking across docs and blog`**
- `docs/introduction.md` — improved description for homepage SEO; added "Getting Started" link section
- `docs/faq.md` — fixed outdated Secure Boot answer; updated 4 headings to be search-query-aligned
- `docs/quick-start.md` — improved description; added "Next Steps" link section
- All 6 blog posts — added missing `description` frontmatter
- 18 doc pages — replaced short/generic descriptions with specific keyword-rich ones
- `docs/kb/pxe/windows.md` title updated to be descriptive

**`fix: correct typo 'suppport' in JetKVM link text in nbxyz-users.md`**
- `docs/community/nbxyz-users.md:38` — `suppport` → `support`

**`fix: correct grammar in FAQ 'What is netboot.xyz' answer`**
- `docs/faq.md` — `is tool` → `is a tool`; `various tools netbooting tools` → `various netbooting tools`

**`fix: revert long titles that broke sidebar, add sidebar_label where needed, move troubleshooting to bottom`**
- `docs/introduction.md` — title reverted to `Introduction`
- `docs/docker/overview.md` — added `sidebar_label: Overview` (long title kept for SEO)
- `docs/kb/pxe/windows.md` — added `sidebar_label: Windows` (long title kept for SEO)
- `docs/troubleshooting/_category_.yml` — created with `position: 8` to move Troubleshooting below FAQ