### PR TITLE
chore: clear build warnings (markdown hook + browserslist db)

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -7,12 +7,14 @@ module.exports = {
   url: "https://netboot.xyz",
   baseUrl: "/",
   onBrokenLinks: "throw",
-  onBrokenMarkdownLinks: "warn",
   favicon: "img/favicon.ico",
   organizationName: "netbootxyz",
   projectName: "netboot.xyz",
   markdown: {
     mermaid: true,
+    hooks: {
+      onBrokenMarkdownLinks: "warn",
+    },
   },
   staticDirectories: ['static'],
   stylesheets: [

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -2,18 +2,18 @@ const XSvg =
   '<svg style="fill: #000000; vertical-align: middle;" width="14" height="14" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"></path></svg>';
 
 module.exports = {
-  title: "netboot.xyz",
-  tagline: "your favorite operating systems in one place",
-  url: "https://netboot.xyz",
-  baseUrl: "/",
-  onBrokenLinks: "throw",
-  favicon: "img/favicon.ico",
-  organizationName: "netbootxyz",
-  projectName: "netboot.xyz",
+  title: 'netboot.xyz',
+  tagline: 'your favorite operating systems in one place',
+  url: 'https://netboot.xyz',
+  baseUrl: '/',
+  onBrokenLinks: 'throw',
+  favicon: 'img/favicon.ico',
+  organizationName: 'netbootxyz',
+  projectName: 'netboot.xyz',
   markdown: {
     mermaid: true,
     hooks: {
-      onBrokenMarkdownLinks: "warn",
+      onBrokenMarkdownLinks: 'warn',
     },
   },
   staticDirectories: ['static'],
@@ -24,16 +24,35 @@ module.exports = {
   themes: ['@docusaurus/theme-mermaid'],
   themeConfig: {
     metadata: [
-      {name: 'keywords', content: 'ipxe, netbootxyz, pxe, linux, os, operating system, install, installer, netboot, netboot.xyz, network boot, tftp, uefi'},
-      {name: 'description', content: 'Network boot your favorite operating systems, installers and utilities from one menu over the network with iPXE'},
+      {
+        name: 'keywords',
+        content:
+          'ipxe, netbootxyz, pxe, linux, os, operating system, install, installer, netboot, netboot.xyz, network boot, tftp, uefi',
+      },
+      {
+        name: 'description',
+        content:
+          'Network boot your favorite operating systems, installers and utilities from one menu over the network with iPXE',
+      },
       {name: 'author', content: 'netboot.xyz team'},
       {property: 'og:type', content: 'website'},
-      {property: 'og:image', content: 'https://netboot.xyz/img/nbxyz_logo_name.png'},
+      {
+        property: 'og:image',
+        content: 'https://netboot.xyz/img/nbxyz_logo_name.png',
+      },
       {name: 'twitter:card', content: 'summary_large_image'},
-      {name: 'twitter:site', content: '@netbootxyz'}
+      {name: 'twitter:site', content: '@netbootxyz'},
     ],
     prism: {
-      additionalLanguages: ['bash', 'yaml', 'json', 'nginx', 'ini', 'powershell', 'python'],
+      additionalLanguages: [
+        'bash',
+        'yaml',
+        'json',
+        'nginx',
+        'ini',
+        'powershell',
+        'python',
+      ],
     },
     docs: {
       sidebar: {
@@ -46,18 +65,18 @@ module.exports = {
       theme: {light: 'neutral', dark: 'dark'},
     },
     announcementBar: {
-      id: "announcementBar-1", // Increment on change
+      id: 'announcementBar-1', // Increment on change
       content: `If you like netboot.xyz, give it a star on <a target="_blank" rel="noopener noreferrer" href="https://github.com/netbootxyz/netboot.xyz">GitHub</a>⭐️, follow us on <a target="_blank" rel="noopener noreferrer" href="https://x.com/netbootxyz">${XSvg}</a> and join our <a target="_blank" rel="noopener noreferrer" href="https://discord.gg/An6PA2a">Discord</a>!`,
     },
     colorMode: {
-      defaultMode: "dark",
+      defaultMode: 'dark',
       respectPrefersColorScheme: true,
       disableSwitch: false,
     },
     algolia: {
-      appId: "BMY28LDVW4",
-      apiKey: "51b51a157c47742003b8943f2c5acc09",
-      indexName: "netboot",
+      appId: 'BMY28LDVW4',
+      apiKey: '51b51a157c47742003b8943f2c5acc09',
+      indexName: 'netboot',
       contextualSearch: true,
       searchParameters: {
         facetFilters: [],
@@ -65,103 +84,103 @@ module.exports = {
       searchPagePath: 'search',
     },
     navbar: {
-      title: "netboot.xyz",
+      title: 'netboot.xyz',
       logo: {
-        alt: "netboot.xyz",
-        src: "img/nbxyz-logo.svg",
-        srcDark: "img/nbxyz-logo-dark.svg",
+        alt: 'netboot.xyz',
+        src: 'img/nbxyz-logo.svg',
+        srcDark: 'img/nbxyz-logo-dark.svg',
       },
       items: [
         {
-          to: "docs",
-          activeBasePath: "docs",
-          label: "Docs",
-          position: "left",
+          to: 'docs',
+          activeBasePath: 'docs',
+          label: 'Docs',
+          position: 'left',
         },
         {
-          to: "downloads",
-          activeBasePath: "downloads",
-          label: "Downloads",
-          position: "left",
+          to: 'downloads',
+          activeBasePath: 'downloads',
+          label: 'Downloads',
+          position: 'left',
         },
         {
-          to: "blog",
-          label: "Blog",
-          position: "left",
+          to: 'blog',
+          label: 'Blog',
+          position: 'left',
         },
         {
-          href: "https://store.netboot.xyz",
-          label: "Store",
-          position: "left",
+          href: 'https://store.netboot.xyz',
+          label: 'Store',
+          position: 'left',
         },
         {
-          href: "https://github.com/sponsors/netbootxyz",
-          label: "Donate",
-          position: "left",
-        },       
+          href: 'https://github.com/sponsors/netbootxyz',
+          label: 'Donate',
+          position: 'left',
+        },
         {
-          href: "https://github.com/netbootxyz/netboot.xyz",
-          position: "right",
-          className: "header-github-link",
-          "aria-label": "GitHub repository",
+          href: 'https://github.com/netbootxyz/netboot.xyz',
+          position: 'right',
+          className: 'header-github-link',
+          'aria-label': 'GitHub repository',
         },
       ],
     },
     footer: {
-      style: "dark",
+      style: 'dark',
       links: [
         {
-          title: "Docs",
+          title: 'Docs',
           items: [
             {
-              label: "Documentation",
-              to: "docs",
+              label: 'Documentation',
+              to: 'docs',
             },
             {
-              label: "Downloads",
-              to: "downloads",
+              label: 'Downloads',
+              to: 'downloads',
             },
             {
-              label: "Blog",
-              to: "blog",
+              label: 'Blog',
+              to: 'blog',
             },
           ],
         },
         {
-          title: "Community",
+          title: 'Community',
           items: [
             {
-              label: "Discord",
-              href: "https://discord.gg/An6PA2a",
+              label: 'Discord',
+              href: 'https://discord.gg/An6PA2a',
             },
             {
-              label: "Discussions",
-              href: "https://github.com/orgs/netbootxyz/discussions",
+              label: 'Discussions',
+              href: 'https://github.com/orgs/netbootxyz/discussions',
             },
             {
-              label: "X",
-              href: "https://x.com/netbootxyz",
+              label: 'X',
+              href: 'https://x.com/netbootxyz',
             },
           ],
         },
         {
-          title: "More",
+          title: 'More',
           items: [
             {
-              label: "Donate",
-              href: "https://opencollective.com/netbootxyz/donate",
+              label: 'Donate',
+              href: 'https://opencollective.com/netbootxyz/donate',
             },
             {
-              label: "GitHub",
-              href: "https://github.com/netbootxyz/netboot.xyz",
+              label: 'GitHub',
+              href: 'https://github.com/netbootxyz/netboot.xyz',
             },
             {
-              label: "Status",
-              href: "https://status.netboot.xyz",
+              label: 'Status',
+              href: 'https://status.netboot.xyz',
             },
             {
-              label: "Store",
-              href: "https://store.netboot.xyz",
+              label: 'Store',
+              href: 'https://store.netboot.xyz',
             },
           ],
         },
@@ -183,23 +202,23 @@ module.exports = {
   ],
   presets: [
     [
-      "@docusaurus/preset-classic",
+      '@docusaurus/preset-classic',
       {
         docs: {
-          sidebarPath: require.resolve("./sidebars.js"),
+          sidebarPath: require.resolve('./sidebars.js'),
           editUrl:
-            "https://github.com/netbootxyz/netboot.xyz-docs/edit/master/",
+            'https://github.com/netbootxyz/netboot.xyz-docs/edit/master/',
         },
         blog: {
           showReadingTime: true,
           editUrl:
-            "https://github.com/netbootxyz/netboot.xyz-docs/edit/master/",
+            'https://github.com/netbootxyz/netboot.xyz-docs/edit/master/',
         },
         theme: {
-          customCss: require.resolve("./src/css/custom.css"),
+          customCss: require.resolve('./src/css/custom.css'),
         },
         gtag: {
-          trackingID: "G-VBSC8VX50S",
+          trackingID: 'G-VBSC8VX50S',
         },
       },
     ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -3802,15 +3802,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001646, caniuse-lite@^1.0.30001688:
-  version "1.0.30001700"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001700.tgz#26cd429cf09b4fd4e745daf4916039c794d720f6"
-  integrity sha512-2S6XIXwaE7K7erT8dY+kLQcpa5ms63XlRkMkReXjle+kf6c5g38vyMl+Z5y8dSxOFDhcFe+nxnn261PLxBSQsQ==
-
-caniuse-lite@^1.0.30001702, caniuse-lite@^1.0.30001718:
-  version "1.0.30001721"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001721.tgz#36b90cd96901f8c98dd6698bf5c8af7d4c6872d7"
-  integrity sha512-cOuvmUVtKrtEaoKiO0rSc29jcjwMwX5tOHDy4MgVFEWiUXj4uBMJkwI8MDySkgXidpMiHUcviogAvFi4pA2hDQ==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001646, caniuse-lite@^1.0.30001688, caniuse-lite@^1.0.30001702, caniuse-lite@^1.0.30001718:
+  version "1.0.30001793"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz"
+  integrity sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==
 
 ccount@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
Noticed two warnings in the `yarn build` output (both pre-existing, surfaced after the redesign merge). This clears them.

## Changes
1. **`onBrokenMarkdownLinks` deprecation** — moved from the top-level config to `markdown.hooks.onBrokenMarkdownLinks` (the old location is deprecated and removed in Docusaurus v4). Behavior unchanged (`"warn"`). `onBrokenLinks` stays top-level — it isn't deprecated.
2. **Stale Browserslist data** — ran `update-browserslist-db@latest` to refresh `caniuse-lite` (was 15 months old). No target-browser changes; just the data table.

## Verify
- [x] `yarn build` passes.
- [x] Deprecation warning: **0 occurrences** in build output (was present before).
- [x] Browserslist staleness warning: **0 occurrences** (was present before).
- [x] No functional/behavior change — purely config-location + dependency-data refresh.

Only remaining build log line is Node's harmless `ExperimentalWarning: localStorage` during SSR prerender (internal to Docusaurus, not actionable).