### PR TITLE
fix: right-size homepage hero & headers on mobile

### DIFF
--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -86,6 +86,7 @@
   letter-spacing: -0.035em;
   margin: 0 0 24px;
   color: var(--nb-ink);
+  text-wrap: balance;
 }
 
 .heroTitle .accent {
@@ -407,5 +408,37 @@
 
   .downloadActions {
     flex-wrap: wrap;
+  }
+}
+
+/* Phones — right-size the headers so the hero doesn't overwhelm a small screen. */
+@media (max-width: 480px) {
+  .section {
+    padding-left: 20px;
+    padding-right: 20px;
+  }
+
+  .hero {
+    gap: 32px;
+    padding-top: 36px;
+    padding-bottom: 40px;
+  }
+
+  .heroTitle {
+    font-size: 33px;
+    line-height: 1.12;
+    letter-spacing: -0.02em;
+  }
+
+  .heroLede {
+    font-size: 16.5px;
+  }
+
+  .h2 {
+    font-size: 25px;
+  }
+
+  .downloadTitle {
+    font-size: 22px;
   }
 }


### PR DESCRIPTION
The homepage hero H1 stayed at 44px all the way down to the 996px breakpoint, so on phones (~390px) it dominated the screen and wrapped into three tight lines.

## Changes (`src/pages/index.module.css` only)
- New **`@media (max-width: 480px)`** breakpoint tuning the headers for phones:
  - hero H1 44px → **33px**, line-height 1.04 → 1.12, looser tracking
  - lede → 16.5px, `Quick start` h2 → 25px, `Get netboot.xyz` → 22px
  - slightly tighter section padding + hero spacing
- **`text-wrap: balance`** on the hero title so its lines wrap evenly ("Your favorite / operating systems, / in one place.") instead of orphaning "systems," on its own line. No-op where the title already fits (desktop/tablet).

## Verify
- [x] `yarn build` passes.
- [x] Checked at 390px in both light and dark (headless Chrome): hero is right-sized and balanced; section headers scale down cleanly; no horizontal overflow.

No behavior changes — CSS only, scoped to the homepage module.